### PR TITLE
Add support for UserSettings folder

### DIFF
--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageExternalUser.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageExternalUser.cs
@@ -1,0 +1,20 @@
+﻿using UnityEditor;
+
+namespace UGF.CustomSettings.Editor.Tests
+{
+    public static class TestSettingsEditorPackageExternalUser
+    {
+        public static CustomSettingsEditorPackage<TestSettingsEditorData> Settings { get; } = new CustomSettingsEditorPackage<TestSettingsEditorData>
+        (
+            "UGF.Test.Editor.Package.External",
+            "TestEditorPackageExternalUserSettings",
+            CustomSettingsEditorUtility.DEFAULT_PACKAGE_EXTERNAL_USER_FOLDER
+        );
+
+        [SettingsProvider]
+        private static SettingsProvider GetSettingsProvider()
+        {
+            return new CustomSettingsProvider<TestSettingsEditorData>("Project/Test/Editor Package External User", Settings, SettingsScope.Project);
+        }
+    }
+}

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageExternalUser.cs.meta
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageExternalUser.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4062581b1fa4465c891408c7805fbda7
+timeCreated: 1600546384

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorUtility.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorUtility.cs
@@ -14,5 +14,10 @@ namespace UGF.CustomSettings.Editor
         /// Represents the default path of the settings data asset used for editor package settings and stored under the 'ProjectSettings' folder.
         /// </summary>
         public const string DEFAULT_PACKAGE_EXTERNAL_FOLDER = "ProjectSettings/Packages";
+
+        /// <summary>
+        /// Represents the default path of the settings data asset used for editor package settings and stored under the 'UserSettings' folder.
+        /// </summary>
+        public const string DEFAULT_PACKAGE_EXTERNAL_USER_FOLDER = "UserSettings/Packages";
     }
 }


### PR DESCRIPTION
- Add `CustomSettingsEditorUtility.DEFAULT_PACKAGE_EXTERNAL_USER_FOLDER` constant to use with settings stored under the `UserSettings` folder, with default value `UserSettings/Packages`.