### PR TITLE
Dont display script field in settings GUI

### DIFF
--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorData.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorData.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using UGF.CustomSettings.Runtime;
 using UnityEngine;
 
 namespace UGF.CustomSettings.Editor.Tests
 {
-    public class TestSettingsEditorData : ScriptableObject
+    public class TestSettingsEditorData : CustomSettingsData
     {
         [SerializeField] private string m_name;
         [SerializeField] private Material m_material;

--- a/Assets/UGF.CustomSettings.Runtime.Tests/TestSettingsData.cs
+++ b/Assets/UGF.CustomSettings.Runtime.Tests/TestSettingsData.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UGF.CustomSettings.Runtime.Tests
 {
-    public class TestSettingsData : ScriptableObject
+    public class TestSettingsData : CustomSettingsData
     {
         [SerializeField] private string m_name;
         [SerializeField] private Material m_material;

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsDataEditor.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsDataEditor.cs
@@ -1,0 +1,16 @@
+﻿using UGF.CustomSettings.Runtime;
+using UnityEditor;
+
+namespace UGF.CustomSettings.Editor
+{
+    [CustomEditor(typeof(CustomSettingsData), true)]
+    public class CustomSettingsDataEditor : UnityEditor.Editor
+    {
+        private readonly string[] m_excluding = { "m_Script" };
+
+        public override void OnInspectorGUI()
+        {
+            DrawPropertiesExcluding(serializedObject, m_excluding);
+        }
+    }
+}

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsDataEditor.cs.meta
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsDataEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0b23da36da544f4c87a1e7051e8c6882
+timeCreated: 1600547859

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsData.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsData.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+namespace UGF.CustomSettings.Runtime
+{
+    public abstract class CustomSettingsData : ScriptableObject
+    {
+    }
+}

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsData.cs.meta
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: abcc8ecd6641476b888f48be61bf52af
+timeCreated: 1600547838


### PR DESCRIPTION
- Add `CustomSettingsData` as default implementation of `ScriptableObject` used for settings data.
- Add `CustomSettingsDataEditor` as default implementation of `Editor` for `CustomSettingsData`, and which do not display `Script` field.