### PR TITLE
Add destroy settings data

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -225,7 +225,6 @@ GameObject:
   m_Component:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
-  - component: {fileID: 963194226}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -233,14 +232,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &963194226
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
 --- !u!20 &963194227
 Camera:
   m_ObjectHideFlags: 0

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorAsset.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorAsset.cs
@@ -4,6 +4,7 @@ using UGF.CustomSettings.Runtime;
 using UGF.EditorTools.Editor.Yaml;
 using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Editor
 {
@@ -76,6 +77,16 @@ namespace UGF.CustomSettings.Editor
                 {
                     AssetDatabase.MoveAssetToTrash(AssetPath);
                 }
+            }
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+            if (HasExternalPath || !Exists())
+            {
+                Object.DestroyImmediate(data);
             }
         }
 

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorPrefs.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorPrefs.cs
@@ -2,6 +2,7 @@ using System;
 using UGF.CustomSettings.Runtime;
 using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Editor
 {
@@ -55,6 +56,13 @@ namespace UGF.CustomSettings.Editor
             base.OnClearSettings();
 
             EditorPrefs.DeleteKey(Key);
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+            Object.DestroyImmediate(data);
         }
     }
 }

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsProvider.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsProvider.cs
@@ -94,6 +94,7 @@ namespace UGF.CustomSettings.Editor
 
         private void CreateEditor()
         {
+            m_settings.LoadSettings();
             m_provider = AssetSettingsProvider.CreateProviderFromObject(string.Empty, m_settings.Data);
             m_provider.OnActivate(string.Empty, null);
         }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Runtime
 {
@@ -25,6 +26,11 @@ namespace UGF.CustomSettings.Runtime
         /// Event triggered after data clear completed.
         /// </summary>
         public event Action Cleared;
+
+        /// <summary>
+        /// Event triggered after data destroy completed.
+        /// </summary>
+        public event Action Destroyed;
 
         /// <summary>
         /// Gets the settings data.
@@ -86,6 +92,8 @@ namespace UGF.CustomSettings.Runtime
         /// </summary>
         public void LoadSettings()
         {
+            DestroySettings();
+
             m_data = OnLoadSettings();
 
             if (m_data == null) throw new ArgumentException($"Data of '{GetType()}' not loaded.");
@@ -101,6 +109,21 @@ namespace UGF.CustomSettings.Runtime
             OnClearSettings();
 
             Cleared?.Invoke();
+        }
+
+        /// <summary>
+        /// Destroys settings data.
+        /// </summary>
+        public void DestroySettings()
+        {
+            if (m_data != null)
+            {
+                OnDestroySettings(m_data);
+
+                m_data = null;
+
+                Destroyed?.Invoke();
+            }
         }
 
         /// <summary>
@@ -123,6 +146,17 @@ namespace UGF.CustomSettings.Runtime
         /// Override this method to implement clear of the data.
         /// </summary>
         protected virtual void OnClearSettings()
+        {
+        }
+
+        /// <summary>
+        /// Override this method to implement destroy of the data.
+        /// </summary>
+        /// <param name="data">The data to destroy.</param>
+        /// <remarks>
+        /// This method invoked only when settings data exists.
+        /// </remarks>
+        protected virtual void OnDestroySettings(TData data)
         {
         }
     }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsFile.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsFile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Runtime
 {
@@ -64,6 +65,13 @@ namespace UGF.CustomSettings.Runtime
             {
                 File.Delete(FilePath);
             }
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+            Object.DestroyImmediate(data);
         }
     }
 }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Runtime
 {
@@ -91,6 +92,18 @@ namespace UGF.CustomSettings.Runtime
             if (Exists())
             {
                 UnityEditor.AssetDatabase.MoveAssetToTrash(AssetPath);
+            }
+#endif
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+#if UNITY_EDITOR
+            if (!Exists())
+            {
+                Object.DestroyImmediate(data);
             }
 #endif
         }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.cs
@@ -45,5 +45,19 @@ namespace UGF.CustomSettings.Runtime
         {
             return !Application.isPlaying;
         }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+#if UNITY_EDITOR
+            if (m_copy != null)
+            {
+                Object.DestroyImmediate(m_copy);
+
+                m_copy = null;
+            }
+#endif
+        }
     }
 }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Runtime
 {
@@ -65,6 +66,13 @@ namespace UGF.CustomSettings.Runtime
             base.OnClearSettings();
 
             PlayerPrefs.DeleteKey(Key);
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+            Object.DestroyImmediate(data);
         }
     }
 }

--- a/ProjectSettings/Packages/UGF.Test.Editor.Package.External/TestEditorPackageExternalSettings.asset
+++ b/ProjectSettings/Packages/UGF.Test.Editor.Package.External/TestEditorPackageExternalSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bf8c44cb4d98d14f9e63735eaa694c6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_name: Test
+  m_name: Test 101
   m_material: {fileID: 0}
   m_mask:
     serializedVersion: 2


### PR DESCRIPTION
- Add `DestroySettings` method with `OnDestroySettings` to override destroy behaviour, non by default.
- Add `Destroyed` event, which triggered after data destroy completed.
- Change `LoadSettings` to destroy exist data object before loading new one.
- Change `CustomSettingsProvider` to force load settings when activated.