### PR TITLE
Fix settings not saving to disk for settings from asset

### DIFF
--- a/Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset
+++ b/Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &11400000
+--- !u!114 &1
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset
+++ b/Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bf8c44cb4d98d14f9e63735eaa694c6, type: 3}
   m_Name: TestEditorPackageSettings
   m_EditorClassIdentifier: 
-  m_name: Test 2
+  m_name: Editor Package
   m_material: {fileID: 0}
   m_mask:
     serializedVersion: 2

--- a/Assets/Settings/Resources/UGF.Test.Package/TestPackageSettings.asset
+++ b/Assets/Settings/Resources/UGF.Test.Package/TestPackageSettings.asset
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &11400000
+--- !u!114 &1
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageChange.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageChange.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+using UGF.EditorTools.Editor.Yaml;
+using UnityEditor;
+
+namespace UGF.CustomSettings.Editor.Tests
+{
+    public class TestSettingsEditorPackageChange
+    {
+        private string m_previousName;
+        private const string PATH = "Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset";
+
+        [OneTimeSetUp]
+        public void SetupAll()
+        {
+            var data = EditorYamlUtility.FromYamlAtPath<TestSettingsEditorData>(PATH);
+
+            m_previousName = data.Name;
+        }
+
+        [OneTimeTearDown]
+        public void TeardownAll()
+        {
+            var data = EditorYamlUtility.FromYamlAtPath<TestSettingsEditorData>(PATH);
+
+            data.Name = m_previousName;
+
+            EditorYamlUtility.ToYamlAtPath(data, PATH);
+            AssetDatabase.ImportAsset(PATH);
+            AssetDatabase.SaveAssets();
+        }
+
+        [Test]
+        public void Change()
+        {
+            string name = "Test Name Change";
+            TestSettingsEditorPackage.Settings.Data.Name = name;
+            TestSettingsEditorPackage.Settings.SaveSettings();
+
+            var data = EditorYamlUtility.FromYamlAtPath<TestSettingsEditorData>(PATH);
+
+            Assert.AreEqual(name, data.Name);
+        }
+    }
+}

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageChange.cs.meta
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageChange.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 662555020e9746ec8c96f95a0eec6173
+timeCreated: 1605032847

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsPackageChange.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsPackageChange.cs
@@ -1,0 +1,45 @@
+﻿using NUnit.Framework;
+using UGF.CustomSettings.Runtime.Tests;
+using UGF.EditorTools.Editor.Yaml;
+using UnityEditor;
+
+namespace UGF.CustomSettings.Editor.Tests
+{
+    public class TestSettingsPackageChange
+    {
+        private string m_previousName;
+        private const string PATH = "Assets/Settings/Resources/UGF.Test.Package/TestPackageSettings.asset";
+
+        [OneTimeSetUp]
+        public void SetupAll()
+        {
+            var data = EditorYamlUtility.FromYamlAtPath<TestSettingsData>(PATH);
+
+            m_previousName = data.Name;
+        }
+
+        [OneTimeTearDown]
+        public void TeardownAll()
+        {
+            var data = EditorYamlUtility.FromYamlAtPath<TestSettingsData>(PATH);
+
+            data.Name = m_previousName;
+
+            EditorYamlUtility.ToYamlAtPath(data, PATH);
+            AssetDatabase.ImportAsset(PATH);
+            AssetDatabase.SaveAssets();
+        }
+
+        [Test]
+        public void Change()
+        {
+            string name = "Test Name Change";
+            TestSettingsPackage.Settings.Data.Name = name;
+            TestSettingsPackage.Settings.SaveSettings();
+
+            var data = EditorYamlUtility.FromYamlAtPath<TestSettingsData>(PATH);
+
+            Assert.AreEqual(name, data.Name);
+        }
+    }
+}

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsPackageChange.cs.meta
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsPackageChange.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 363f4094cb05477b95584e0ceff5a598
+timeCreated: 1605033768

--- a/Assets/UGF.CustomSettings.Editor.Tests/UGF.CustomSettings.Editor.Tests.asmdef
+++ b/Assets/UGF.CustomSettings.Editor.Tests/UGF.CustomSettings.Editor.Tests.asmdef
@@ -1,9 +1,11 @@
 {
     "name": "UGF.CustomSettings.Editor.Tests",
+    "rootNamespace": "",
     "references": [
         "GUID:ff62901452104d14cae29322ac133c05",
         "GUID:4806a292f99efd44aba38aea20847e17",
-        "GUID:96b268adc5d7ab34c9c7b88aae60b2bc"
+        "GUID:96b268adc5d7ab34c9c7b88aae60b2bc",
+        "GUID:abdd615e45137c74ca2ce9c636c78c15"
     ],
     "includePlatforms": [
         "Editor"
@@ -18,5 +20,6 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorAsset.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorAsset.cs
@@ -15,8 +15,6 @@ namespace UGF.CustomSettings.Editor
     /// This settings supports saving and loading settings data asset whether asset path points to file under the 'Assets' folder or not.
     ///
     /// In editor settings data asset automatically created at specified asset path, if asset not yet created.
-    ///
-    /// A calling of the 'SaveSettings' method has effect only for assets out of the 'Assets' folder.
     /// </remarks>
     public class CustomSettingsEditorAsset<TData> : CustomSettings<TData> where TData : ScriptableObject
     {
@@ -47,11 +45,6 @@ namespace UGF.CustomSettings.Editor
             return File.Exists(AssetPath);
         }
 
-        public override bool CanSave()
-        {
-            return !Exists() || HasExternalPath;
-        }
-
         protected override void OnSaveSettings(TData data)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
@@ -61,11 +54,20 @@ namespace UGF.CustomSettings.Editor
                 CustomSettingsUtility.CheckAndCreateDirectory(AssetPath);
                 EditorYamlUtility.ToYamlAtPath(data, AssetPath);
             }
-            else if (!Exists())
+            else
             {
-                CustomSettingsUtility.CheckAndCreateDirectory(AssetPath);
-                AssetDatabase.CreateAsset(data, AssetPath);
-                AssetDatabase.ImportAsset(AssetPath);
+                if (Exists())
+                {
+                    EditorUtility.SetDirty(data);
+                }
+                else
+                {
+                    CustomSettingsUtility.CheckAndCreateDirectory(AssetPath);
+                    AssetDatabase.CreateAsset(data, AssetPath);
+                    AssetDatabase.ImportAsset(AssetPath);
+                }
+
+                AssetDatabase.SaveAssets();
             }
         }
 

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
@@ -138,7 +138,7 @@ namespace UGF.CustomSettings.Runtime
         /// </summary>
         protected virtual TData OnLoadSettings()
         {
-            throw new InvalidOperationException($"Loading of '{GetType()}' not implemented.");
+            throw new InvalidOperationException($"Settings has no loading implementation for specified type: '{GetType()}'.");
         }
 
         /// <summary>

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Runtime
 {

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.Editor.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.Editor.cs
@@ -1,0 +1,69 @@
+﻿#if UNITY_EDITOR
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UGF.CustomSettings.Runtime
+{
+    public partial class CustomSettingsPackage<TData>
+    {
+        public override bool Exists()
+        {
+            return File.Exists(AssetPath);
+        }
+
+        protected override void OnSaveSettings(TData data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            if (Exists())
+            {
+                EditorUtility.SetDirty(data);
+            }
+            else
+            {
+                CustomSettingsUtility.CheckAndCreateDirectory(AssetPath);
+
+                AssetDatabase.CreateAsset(data, AssetPath);
+                AssetDatabase.ImportAsset(AssetPath);
+            }
+
+            AssetDatabase.SaveAssets();
+        }
+
+        protected override TData OnLoadSettings()
+        {
+            if (!Exists())
+            {
+                var data = ScriptableObject.CreateInstance<TData>();
+
+                OnSaveSettings(data);
+            }
+
+            return base.OnLoadSettings();
+        }
+
+        protected override void OnClearSettings()
+        {
+            base.OnClearSettings();
+
+            if (Exists())
+            {
+                AssetDatabase.MoveAssetToTrash(AssetPath);
+            }
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+            if (!Exists())
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+    }
+}
+#endif

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.Editor.cs.meta
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.Editor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cfe91a27f0014317b3fe4dc6d36d1eba
+timeCreated: 1605034036

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.cs
@@ -1,7 +1,5 @@
 using System;
-using System.IO;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace UGF.CustomSettings.Runtime
 {
@@ -16,7 +14,7 @@ namespace UGF.CustomSettings.Runtime
     ///
     /// The default folder path is 'Assets/Settings/Resources'.
     /// </remarks>
-    public class CustomSettingsPackage<TData> : CustomSettingsResources<TData> where TData : ScriptableObject
+    public partial class CustomSettingsPackage<TData> : CustomSettingsResources<TData> where TData : ScriptableObject
     {
         /// <summary>
         /// Gets the path of the folder to store settings data asset.
@@ -47,70 +45,6 @@ namespace UGF.CustomSettings.Runtime
 
             FolderPath = folderPath;
             AssetPath = $"{FolderPath}/{ResourcesPath}.asset";
-        }
-
-        public override bool Exists()
-        {
-#if UNITY_EDITOR
-            return File.Exists(AssetPath);
-#else
-            return base.Exists();
-#endif
-        }
-
-        public override bool CanSave()
-        {
-            return !Exists();
-        }
-
-        protected override void OnSaveSettings(TData data)
-        {
-#if UNITY_EDITOR
-            if (data == null) throw new ArgumentNullException(nameof(data));
-
-            CustomSettingsUtility.CheckAndCreateDirectory(AssetPath);
-
-            UnityEditor.AssetDatabase.CreateAsset(data, AssetPath);
-            UnityEditor.AssetDatabase.ImportAsset(AssetPath);
-#endif
-        }
-
-        protected override TData OnLoadSettings()
-        {
-#if UNITY_EDITOR
-            if (!Exists())
-            {
-                var data = ScriptableObject.CreateInstance<TData>();
-
-                OnSaveSettings(data);
-            }
-#endif
-
-            return base.OnLoadSettings();
-        }
-
-        protected override void OnClearSettings()
-        {
-            base.OnClearSettings();
-
-#if UNITY_EDITOR
-            if (Exists())
-            {
-                UnityEditor.AssetDatabase.MoveAssetToTrash(AssetPath);
-            }
-#endif
-        }
-
-        protected override void OnDestroySettings(TData data)
-        {
-            base.OnDestroySettings(data);
-
-#if UNITY_EDITOR
-            if (!Exists())
-            {
-                Object.DestroyImmediate(data);
-            }
-#endif
         }
     }
 }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.Editor.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.Editor.cs
@@ -1,0 +1,53 @@
+﻿#if UNITY_EDITOR
+using UnityEngine;
+
+namespace UGF.CustomSettings.Runtime
+{
+    public abstract partial class CustomSettingsPlayMode<TData>
+    {
+        public override TData Data
+        {
+            get
+            {
+                if (Application.isPlaying)
+                {
+                    if (m_copy == null)
+                    {
+                        m_copy = Object.Instantiate(base.Data);
+                    }
+
+                    return m_copy;
+                }
+
+                DestroyCopy();
+
+                return base.Data;
+            }
+        }
+
+        private TData m_copy;
+
+        public override bool CanSave()
+        {
+            return !Application.isPlaying;
+        }
+
+        protected override void OnDestroySettings(TData data)
+        {
+            base.OnDestroySettings(data);
+
+            DestroyCopy();
+        }
+
+        private void DestroyCopy()
+        {
+            if (m_copy != null)
+            {
+                Object.DestroyImmediate(m_copy);
+
+                m_copy = null;
+            }
+        }
+    }
+}
+#endif

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.Editor.cs.meta
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.Editor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 91bfe841ceed4895891e2d91e4df9135
+timeCreated: 1605034324

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.cs
@@ -9,55 +9,7 @@ namespace UGF.CustomSettings.Runtime
     /// In play mode returns copy of the original settings data and saving not available.
     /// In build just returns the original settings data.
     /// </remarks>
-    public abstract class CustomSettingsPlayMode<TData> : CustomSettings<TData> where TData : ScriptableObject
+    public abstract partial class CustomSettingsPlayMode<TData> : CustomSettings<TData> where TData : ScriptableObject
     {
-        public override TData Data
-        {
-            get
-            {
-#if UNITY_EDITOR
-                if (Application.isPlaying)
-                {
-                    if (m_copy == null)
-                    {
-                        m_copy = Object.Instantiate(base.Data);
-                    }
-
-                    return m_copy;
-                }
-
-                if (m_copy != null)
-                {
-                    Object.DestroyImmediate(m_copy);
-
-                    m_copy = null;
-                }
-#endif
-                return base.Data;
-            }
-        }
-
-#if UNITY_EDITOR
-        private TData m_copy;
-#endif
-
-        public override bool CanSave()
-        {
-            return !Application.isPlaying;
-        }
-
-        protected override void OnDestroySettings(TData data)
-        {
-            base.OnDestroySettings(data);
-
-#if UNITY_EDITOR
-            if (m_copy != null)
-            {
-                Object.DestroyImmediate(m_copy);
-
-                m_copy = null;
-            }
-#endif
-        }
     }
 }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsResources.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsResources.cs
@@ -32,11 +32,6 @@ namespace UGF.CustomSettings.Runtime
             return Resources.Load<TData>(ResourcesPath) != null;
         }
 
-        public override bool CanSave()
-        {
-            return false;
-        }
-
         protected override void OnSaveSettings(TData data)
         {
         }

--- a/ProjectSettings/Packages/UGF.Test.Editor.Package.External/TestEditorPackageExternalSettings.asset
+++ b/ProjectSettings/Packages/UGF.Test.Editor.Package.External/TestEditorPackageExternalSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bf8c44cb4d98d14f9e63735eaa694c6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_name: Test 101
+  m_name: Editor Package External
   m_material: {fileID: 0}
   m_mask:
     serializedVersion: 2
@@ -20,4 +20,4 @@ MonoBehaviour:
   m_state: 0
   m_list: []
   m_list2: []
-  m_vector3: {x: 1.77, y: 5.75, z: 2.2}
+  m_vector3: {x: 4.22, y: 5.75, z: 2.2}

--- a/UGF.CustomSettings.Editor.csproj.DotSettings
+++ b/UGF.CustomSettings.Editor.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Cugf_002Ecustomsettings_005Ceditor/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
- Fix `CustomSettingsEditorAsset` and `CustomSettingsPackage` does not saving changes on disk when modify them via code.
- Change `CustomSettingsResources` always allows saving, but it has no effect.