### PR TITLE
Change data property to method

### DIFF
--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditor.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditor.cs
@@ -7,13 +7,13 @@ namespace UGF.CustomSettings.Editor.Tests
         [Test]
         public void Package()
         {
-            Assert.AreEqual("Editor Package", TestSettingsEditorPackage.Settings.Data.Name);
+            Assert.AreEqual("Editor Package", TestSettingsEditorPackage.Settings.GetData().Name);
         }
 
         [Test]
         public void PackageExternal()
         {
-            Assert.AreEqual("Editor Package External", TestSettingsEditorPackageExternal.Settings.Data.Name);
+            Assert.AreEqual("Editor Package External", TestSettingsEditorPackageExternal.Settings.GetData().Name);
         }
     }
 }

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageChange.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackageChange.cs
@@ -33,7 +33,7 @@ namespace UGF.CustomSettings.Editor.Tests
         public void Change()
         {
             string name = "Test Name Change";
-            TestSettingsEditorPackage.Settings.Data.Name = name;
+            TestSettingsEditorPackage.Settings.GetData().Name = name;
             TestSettingsEditorPackage.Settings.SaveSettings();
 
             var data = EditorYamlUtility.FromYamlAtPath<TestSettingsEditorData>(PATH);

--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsPackageChange.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsPackageChange.cs
@@ -34,7 +34,7 @@ namespace UGF.CustomSettings.Editor.Tests
         public void Change()
         {
             string name = "Test Name Change";
-            TestSettingsPackage.Settings.Data.Name = name;
+            TestSettingsPackage.Settings.GetData().Name = name;
             TestSettingsPackage.Settings.SaveSettings();
 
             var data = EditorYamlUtility.FromYamlAtPath<TestSettingsData>(PATH);

--- a/Assets/UGF.CustomSettings.Runtime.Tests/TestSettings.cs
+++ b/Assets/UGF.CustomSettings.Runtime.Tests/TestSettings.cs
@@ -7,13 +7,13 @@ namespace UGF.CustomSettings.Runtime.Tests
         [Test]
         public void File()
         {
-            Assert.AreEqual("File", TestSettingsFile.Settings.Data.Name);
+            Assert.AreEqual("File", TestSettingsFile.Settings.GetData().Name);
         }
 
         [Test]
         public void Package()
         {
-            Assert.AreEqual("Package", TestSettingsPackage.Settings.Data.Name);
+            Assert.AreEqual("Package", TestSettingsPackage.Settings.GetData().Name);
         }
     }
 }

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsDrawer.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsDrawer.cs
@@ -14,7 +14,7 @@ namespace UGF.CustomSettings.Editor
         public CustomSettingsDrawer(CustomSettings<TData> settings)
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
-            Drawer.Set(Settings.Data);
+            Drawer.Set(Settings.GetData());
         }
 
         public void Enable()

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsProvider.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsProvider.cs
@@ -23,7 +23,7 @@ namespace UGF.CustomSettings.Editor
         /// <param name="settings">The settings of the specific data to display.</param>
         /// <param name="scopes">The scope of the settings.</param>
         /// <param name="keywords">The search keywords.</param>
-        public CustomSettingsProvider(string path, CustomSettings<TData> settings, SettingsScope scopes, IEnumerable<string> keywords = null) : base(path, scopes, keywords ?? GetSearchKeywordsFromSerializedObject(new SerializedObject(settings.Data)))
+        public CustomSettingsProvider(string path, CustomSettings<TData> settings, SettingsScope scopes, IEnumerable<string> keywords = null) : base(path, scopes, keywords ?? GetSearchKeywordsFromSerializedObject(new SerializedObject(settings.GetData())))
         {
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
@@ -97,7 +97,7 @@ namespace UGF.CustomSettings.Editor
         {
             Settings.LoadSettings();
 
-            m_provider = AssetSettingsProvider.CreateProviderFromObject(string.Empty, Settings.Data);
+            m_provider = AssetSettingsProvider.CreateProviderFromObject(string.Empty, Settings.GetData());
             m_provider.OnActivate(string.Empty, null);
         }
     }

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace UGF.CustomSettings.Runtime
+{
+    public abstract partial class CustomSettings<TData>
+    {
+        [Obsolete("Property Data has been deprecated. Use GetData() method instead.")]
+        public virtual TData Data { get { return GetData(); } }
+    }
+}

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs.meta
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e251ccf087b84471a5a7272c658b15a9
+timeCreated: 1605195803

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
@@ -9,7 +9,7 @@ namespace UGF.CustomSettings.Runtime
     /// <remarks>
     /// Inherit this class to implement settings load and save behaviour.
     /// </remarks>
-    public abstract class CustomSettings<TData> where TData : ScriptableObject
+    public abstract partial class CustomSettings<TData> where TData : ScriptableObject
     {
         /// <summary>
         /// Event triggered after data saving completed.
@@ -31,26 +31,18 @@ namespace UGF.CustomSettings.Runtime
         /// </summary>
         public event Action Destroyed;
 
+        private TData m_data;
+
         /// <summary>
         /// Gets the settings data.
         /// </summary>
         /// <remarks>
         /// If the settings data not yet loaded, the loading will be triggered.
         /// </remarks>
-        public virtual TData Data
+        public TData GetData()
         {
-            get
-            {
-                if (m_data == null)
-                {
-                    LoadSettings();
-                }
-
-                return m_data;
-            }
+            return OnGetData();
         }
-
-        private TData m_data;
 
         /// <summary>
         /// Determines whether settings data can be saved.
@@ -123,6 +115,16 @@ namespace UGF.CustomSettings.Runtime
 
                 Destroyed?.Invoke();
             }
+        }
+
+        protected virtual TData OnGetData()
+        {
+            if (m_data == null)
+            {
+                LoadSettings();
+            }
+
+            return m_data;
         }
 
         /// <summary>

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.Editor.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPlayMode.Editor.cs
@@ -5,27 +5,24 @@ namespace UGF.CustomSettings.Runtime
 {
     public abstract partial class CustomSettingsPlayMode<TData>
     {
-        public override TData Data
-        {
-            get
-            {
-                if (Application.isPlaying)
-                {
-                    if (m_copy == null)
-                    {
-                        m_copy = Object.Instantiate(base.Data);
-                    }
+        private TData m_copy;
 
-                    return m_copy;
+        protected override TData OnGetData()
+        {
+            if (Application.isPlaying)
+            {
+                if (m_copy == null)
+                {
+                    m_copy = Object.Instantiate(base.OnGetData());
                 }
 
-                DestroyCopy();
-
-                return base.Data;
+                return m_copy;
             }
-        }
 
-        private TData m_copy;
+            DestroyCopy();
+
+            return base.OnGetData();
+        }
 
         public override bool CanSave()
         {


### PR DESCRIPTION
- Property `CustomSettings<T>.Data` has been deprecated, use `CustomSettings<T>.GetData()` method instead.
- Add `OnGetData()` method to override data loading behaviour.