### PR TITLE
Add force save settings

### DIFF
--- a/Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset
+++ b/Assets/Settings/Editor/UGF.Test.Editor.Package/TestEditorPackageSettings.asset
@@ -20,4 +20,4 @@ MonoBehaviour:
   m_state: 0
   m_list: []
   m_list2: []
-  m_vector3: {x: 9.78, y: 0.54, z: 1.43}
+  m_vector3: {x: 33, y: 0.54, z: 1.43}

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorAsset.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorAsset.cs
@@ -45,7 +45,7 @@ namespace UGF.CustomSettings.Editor
             return File.Exists(AssetPath);
         }
 
-        protected override void OnSaveSettings(TData data)
+        protected override void OnSaveSettings(TData data, bool force)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 
@@ -67,7 +67,10 @@ namespace UGF.CustomSettings.Editor
                     AssetDatabase.ImportAsset(AssetPath);
                 }
 
-                AssetDatabase.SaveAssets();
+                if (force)
+                {
+                    AssetDatabase.SaveAssets();
+                }
             }
         }
 
@@ -77,7 +80,7 @@ namespace UGF.CustomSettings.Editor
             {
                 var data = ScriptableObject.CreateInstance<TData>();
 
-                OnSaveSettings(data);
+                OnSaveSettings(data, true);
             }
 
             return HasExternalPath ? EditorYamlUtility.FromYamlAtPath<TData>(AssetPath) : AssetDatabase.LoadAssetAtPath<TData>(AssetPath);

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorPrefs.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsEditorPrefs.cs
@@ -32,7 +32,7 @@ namespace UGF.CustomSettings.Editor
             return EditorPrefs.HasKey(Key);
         }
 
-        protected override void OnSaveSettings(TData data)
+        protected override void OnSaveSettings(TData data, bool force)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 

--- a/Packages/UGF.CustomSettings/Editor/CustomSettingsProvider.cs
+++ b/Packages/UGF.CustomSettings/Editor/CustomSettingsProvider.cs
@@ -45,6 +45,8 @@ namespace UGF.CustomSettings.Editor
             ClearEditor();
 
             base.OnDeactivate();
+
+            Settings.SaveSettings();
         }
 
         public override void OnGUI(string searchContext)
@@ -57,7 +59,7 @@ namespace UGF.CustomSettings.Editor
 
                 if (EditorGUI.EndChangeCheck())
                 {
-                    Settings.SaveSettings();
+                    Settings.SaveSettings(false);
                 }
             }
 

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace UGF.CustomSettings.Runtime
+{
+    public abstract partial class CustomSettings<TData>
+    {
+        /// <summary>
+        /// Override this method to implement saving of the data.
+        /// </summary>
+        /// <param name="data">The data to save.</param>
+        [Obsolete("Method OnSaveSettings(T data) has been deprecated. Use OnSaveSettings(T data, bool force) instead.")]
+        protected virtual void OnSaveSettings(TData data)
+        {
+            OnSaveSettings(data, true);
+        }
+    }
+}

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs.meta
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 033479df44d24ccc83ba7ecbd00ce167
+timeCreated: 1605198849

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
@@ -9,7 +9,7 @@ namespace UGF.CustomSettings.Runtime
     /// <remarks>
     /// Inherit this class to implement settings load and save behaviour.
     /// </remarks>
-    public abstract class CustomSettings<TData> where TData : ScriptableObject
+    public abstract partial class CustomSettings<TData> where TData : ScriptableObject
     {
         /// <summary>
         /// Event triggered after data saving completed.
@@ -74,13 +74,14 @@ namespace UGF.CustomSettings.Runtime
         /// <remarks>
         /// <see cref="CanSave"/> determines whether settings can be saved.
         /// </remarks>
-        public void SaveSettings()
+        /// <param name="force">The value that determines whether to force data serialization.</param>
+        public void SaveSettings(bool force = true)
         {
             if (CanSave())
             {
                 if (m_data == null) throw new ArgumentException($"Data of '{GetType()}' not specified.");
 
-                OnSaveSettings(m_data);
+                OnSaveSettings(m_data, force);
 
                 Saved?.Invoke(m_data);
             }
@@ -129,7 +130,8 @@ namespace UGF.CustomSettings.Runtime
         /// Override this method to implement saving of the data.
         /// </summary>
         /// <param name="data">The data to save.</param>
-        protected virtual void OnSaveSettings(TData data)
+        /// <param name="force">The value that determines whether to force data serialization.</param>
+        protected virtual void OnSaveSettings(TData data, bool force)
         {
         }
 

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsFile.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsFile.cs
@@ -31,7 +31,7 @@ namespace UGF.CustomSettings.Runtime
             return File.Exists(FilePath);
         }
 
-        protected override void OnSaveSettings(TData data)
+        protected override void OnSaveSettings(TData data, bool force)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.Editor.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPackage.Editor.cs
@@ -14,7 +14,7 @@ namespace UGF.CustomSettings.Runtime
             return File.Exists(AssetPath);
         }
 
-        protected override void OnSaveSettings(TData data)
+        protected override void OnSaveSettings(TData data, bool force)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 
@@ -30,7 +30,10 @@ namespace UGF.CustomSettings.Runtime
                 AssetDatabase.ImportAsset(AssetPath);
             }
 
-            AssetDatabase.SaveAssets();
+            if (force)
+            {
+                AssetDatabase.SaveAssets();
+            }
         }
 
         protected override TData OnLoadSettings()
@@ -39,7 +42,7 @@ namespace UGF.CustomSettings.Runtime
             {
                 var data = ScriptableObject.CreateInstance<TData>();
 
-                OnSaveSettings(data);
+                OnSaveSettings(data, true);
             }
 
             return base.OnLoadSettings();

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.Deprecated.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.Deprecated.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace UGF.CustomSettings.Runtime
+{
+    public partial class CustomSettingsPrefs<TData>
+    {
+        /// <summary>
+        /// Gets the value that determines whether to force player prefs saving each time when settings saving performed.
+        /// </summary>
+        [Obsolete("Property ForceSave has been deprecated.")]
+        public bool ForceSave { get; }
+
+        /// <summary>
+        /// Creates settings with the specified player prefs key.
+        /// </summary>
+        /// <param name="key">The key of the data in player prefs.</param>
+        /// <param name="forceSave">The value that determines whether to save player prefs when settings saving performed.</param>
+        [Obsolete("Constructor CustomSettingsPrefs(string key, bool forceSave) has been deprecated.")]
+        public CustomSettingsPrefs(string key, bool forceSave)
+        {
+            if (string.IsNullOrEmpty(key)) throw new ArgumentException("The prefs key cannot be null or empty.", nameof(key));
+
+            Key = key;
+            ForceSave = forceSave;
+        }
+    }
+}

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.Deprecated.cs.meta
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.Deprecated.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 01372c45781e4bea929fab32e2521e5e
+timeCreated: 1605197851

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsPrefs.cs
@@ -7,7 +7,7 @@ namespace UGF.CustomSettings.Runtime
     /// <summary>
     /// Represents custom settings which stores data at specified key in player prefs as Json representation.
     /// </summary>
-    public class CustomSettingsPrefs<TData> : CustomSettingsPlayMode<TData> where TData : ScriptableObject
+    public partial class CustomSettingsPrefs<TData> : CustomSettingsPlayMode<TData> where TData : ScriptableObject
     {
         /// <summary>
         /// Gets the key which used to store data in player prefs.
@@ -15,21 +15,14 @@ namespace UGF.CustomSettings.Runtime
         public string Key { get; }
 
         /// <summary>
-        /// Gets the value that determines whether to force player prefs saving each time when settings saving performed.
-        /// </summary>
-        public bool ForceSave { get; }
-
-        /// <summary>
         /// Creates settings with the specified player prefs key.
         /// </summary>
         /// <param name="key">The key of the data in player prefs.</param>
-        /// <param name="forceSave">The value that determines whether to save player prefs when settings saving performed.</param>
-        public CustomSettingsPrefs(string key, bool forceSave = false)
+        public CustomSettingsPrefs(string key)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentException("The prefs key cannot be null or empty.", nameof(key));
 
             Key = key;
-            ForceSave = forceSave;
         }
 
         public override bool Exists()
@@ -37,18 +30,14 @@ namespace UGF.CustomSettings.Runtime
             return PlayerPrefs.HasKey(Key);
         }
 
-        protected override void OnSaveSettings(TData data)
+        protected override void OnSaveSettings(TData data, bool force)
         {
             if (data == null) throw new ArgumentNullException(nameof(data));
 
             string text = JsonUtility.ToJson(data);
 
             PlayerPrefs.SetString(Key, text);
-
-            if (ForceSave)
-            {
-                PlayerPrefs.Save();
-            }
+            PlayerPrefs.Save();
         }
 
         protected override TData OnLoadSettings()

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettingsResources.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettingsResources.cs
@@ -32,7 +32,7 @@ namespace UGF.CustomSettings.Runtime
             return Resources.Load<TData>(ResourcesPath) != null;
         }
 
-        protected override void OnSaveSettings(TData data)
+        protected override void OnSaveSettings(TData data, bool force)
         {
         }
 


### PR DESCRIPTION
- Method `CustomSettings<T>.OnSaveSettings(T data)` has been deprecated. Use `CustomSettings<T>.OnSaveSettings(T data, bool force)` instead.
- Add `force` optional argument for `CustomSettings<T>.SaveSettings()` method, to determines whether to force serialization of the settings data.
- Change `CustomSettingsPrefs<T>.ForceSave` property to be deprecated, `PlayerPrefs.Save()` now always executed.