### PR TITLE
Add settings provider to ask before trigger data creation

### DIFF
--- a/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackage.cs
+++ b/Assets/UGF.CustomSettings.Editor.Tests/TestSettingsEditorPackage.cs
@@ -10,7 +10,10 @@ namespace UGF.CustomSettings.Editor.Tests
             "UGF.Test.Editor.Package",
             "TestEditorPackageSettings",
             CustomSettingsEditorUtility.DEFAULT_PACKAGE_FOLDER
-        );
+        )
+        {
+            ForceCreation = true
+        };
 
         [SettingsProvider, UsedImplicitly]
         private static SettingsProvider GetSettingsProvider()

--- a/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
+++ b/Packages/UGF.CustomSettings/Runtime/CustomSettings.cs
@@ -12,6 +12,21 @@ namespace UGF.CustomSettings.Runtime
     public abstract partial class CustomSettings<TData> where TData : ScriptableObject
     {
         /// <summary>
+        /// Gets type of data used to store settings.
+        /// </summary>
+        public Type DataType { get; } = typeof(TData);
+
+        /// <summary>
+        /// Gets or sets value that determines whether to force data creation in project when file not exist yet, instead of asking user for permission.
+        /// </summary>
+        public bool ForceCreation { get; set; }
+
+        /// <summary>
+        /// Gets value that determines whether settings data is loaded.
+        /// </summary>
+        public bool IsLoaded { get { return m_data != null; } }
+
+        /// <summary>
         /// Event triggered after data saving completed.
         /// </summary>
         public event Action<TData> Saved;
@@ -69,10 +84,8 @@ namespace UGF.CustomSettings.Runtime
         /// <param name="force">The value that determines whether to force data serialization.</param>
         public void SaveSettings(bool force = true)
         {
-            if (CanSave())
+            if (CanSave() && IsLoaded)
             {
-                if (m_data == null) throw new ArgumentException($"Data of '{GetType()}' not specified.");
-
                 OnSaveSettings(m_data, force);
 
                 Saved?.Invoke(m_data);


### PR DESCRIPTION
- Add `CustomSettings<T>.DataType` property which returns type of data settings use.
- Add `CustomSettings<T>.ForceCreation` property to determine whether to always create data when accessed.
- Add `CustomSettings<T>.IsLoaded` property to determine whether data is already loaded.
- Change `CustomSettings<T>.SaveSettings()` method behaviour, now checks whether data is loaded or not, before saving.
- Change `CustomSettingsProvider` to check whether data exists before display data in settings, and ask user for create permission, unless settings has enabled property to force data creation.